### PR TITLE
Add support for "const" keyword in JSON schema

### DIFF
--- a/django_custom_jsonfield/rest_framework/openapi.py
+++ b/django_custom_jsonfield/rest_framework/openapi.py
@@ -48,6 +48,12 @@ class CustomJSONFieldSerializerExtension(OpenApiSerializerFieldExtension):
     def map_serializer_field(self, auto_schema, direction):
         schema = self.target.schema
 
+        if "const" in schema:
+            if schema["const"] is None:
+                return None
+
+            return {"enum": [schema["const"]]}
+
         try:
             if schema["type"] == "object":
                 return self.build_object_schema(schema)

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -48,6 +49,26 @@ def test_map_serializer_field_ok(schema: dict):
     extension = CustomJSONFieldSerializerExtension(json_field)
     data = extension.map_serializer_field(Mock(), "response")
     assert data == schema
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        ({"const": 10}, {"enum": [10]}),  # integer
+        ({"const": 10.00}, {"enum": [10.00]}),  # float
+        ({"const": 10.00}, {"enum": [10.00]}),  # bytes
+        ({"const": "string"}, {"enum": ["string"]}),  # string
+        ({"const": True}, {"enum": [True]}),  # bool
+        ({"const": None}, None),  # none
+    ],
+)
+def test_map_serializer_field_const(schema: dict, expected: Any):
+    """Test basic types declared as const in JSON schema."""
+
+    json_field = CustomJSONField(schema=schema)
+    extension = CustomJSONFieldSerializerExtension(json_field)
+    data = extension.map_serializer_field(Mock(), "response")
+    assert data == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -60,6 +60,8 @@ def test_map_serializer_field_ok(schema: dict):
         ({"const": "string"}, {"enum": ["string"]}),  # string
         ({"const": True}, {"enum": [True]}),  # bool
         ({"const": None}, None),  # none
+        ({"const": {"k": "v", "k2": 10}}, {"enum": [{"k": "v", "k2": 10}]}),  # dict
+        ({"const": [10, 20]}, {"enum": [[10, 20]]}),  # list
     ],
 )
 def test_map_serializer_field_const(schema: dict, expected: Any):


### PR DESCRIPTION
Add support for "const" keyword in JSON schema to properly render schemas using OpenAPI extension.